### PR TITLE
Fix for using sources with a map.

### DIFF
--- a/tasks/static.js
+++ b/tasks/static.js
@@ -16,11 +16,12 @@ module.exports = function(grunt) {
     }
     async.series(_.map(config.build, function(source, target) {
       return function(complete) {
-        var sources = typeof source === 'string' ? [source] : source,
-            output = '';
-        async.series(sources.map(function(source) {
+        var sourceData = source.file ? source.file : source,
+            sources = typeof sourceData === 'string' ? [sourceData] : sourceData,
+            output = ''
+        async.series(sources.map(function(sourceFile) {
           return function(next) {
-            static.transform(typeof source === 'object' ? source.file : source, function(buffer) {
+            static.transform(sourceFile, function(buffer) {
               output += buffer.toString();
               next();
             }, typeof source === 'object' ? source.context: undefined);


### PR DESCRIPTION
sources.map() was giving map undefined when using this style:
'target2.html': {
          file: 'source.hbs.html',
          context: {
            key: 'value'
          }
        }

Fix is to first see if the source has a file attribute and use that.
This has the upside of allowing an array of sources even when using
the above notation.
